### PR TITLE
Added documentation for the Ad-hoc connections extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Currently the available extensions are:
 * auth-cas - [CAS Authentication](https://guacamole.apache.org/doc/gug/cas-auth.html)
 * auth-openid - [OpenID Connect authentication](https://guacamole.apache.org/doc/gug/openid-auth.html)
 * auth-totp - [TOTP two-factor authentication](https://guacamole.apache.org/doc/gug/totp-auth.html)
+* auth-quickconnect - [Ad-hoc connections extension](https://guacamole.apache.org/doc/gug/adhoc-connections.html)
 
 You should only enable the extensions you require, if an extensions is not configured correctly in the `guacamole.properties` file it may prevent the system from loading. See the [official documentation](https://guacamole.apache.org/doc/gug/) for more details.
 


### PR DESCRIPTION
I added some documentation for the Ad-hoc connections extension introduced for Guacamole 1.0.0. Here is the Github issue regarding this feature: https://github.com/oznu/docker-guacamole/issues/27